### PR TITLE
Fix tests: add withoutVite() to prevent ViteManifestNotFoundException

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,11 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     protected bool $seed = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
 }


### PR DESCRIPTION
Fix test setup after removing built Vite assets from repository.

Added `withoutVite()` call in `TestCase` setUp method to prevent tests from attempting to load the Vite manifest file.

Fixes #1756

Generated with [Claude Code](https://claude.ai/code)